### PR TITLE
Match v5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ lol_assets
 credentials.json
 
 .ssl
+
+Riot-Watcher-master

--- a/server/gunicorn/.dockerignore
+++ b/server/gunicorn/.dockerignore
@@ -1,6 +1,6 @@
 env/
 
-__pycache__/
+__pycache__
 
 mooncaker.log
 

--- a/server/gunicorn/Dockerfile
+++ b/server/gunicorn/Dockerfile
@@ -9,6 +9,10 @@ RUN chmod +x /start.sh
 
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN chmod +x install_riot_watcher.sh
+
+RUN ./install_riot_watcher.sh
+
 EXPOSE 5000 587
 
 ENV PYTHONPATH=/mooncaker

--- a/server/gunicorn/install_riot_watcher.sh
+++ b/server/gunicorn/install_riot_watcher.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env sh
+
+wget https://github.com/pseudonym117/Riot-Watcher/archive/refs/heads/master.zip
+unzip master.zip -d .
+cd Riot-Watcher-master
+python setup.py install
+cd ..
+# rm -r -f Riot-Watcher-master/

--- a/server/gunicorn/install_riot_watcher.sh
+++ b/server/gunicorn/install_riot_watcher.sh
@@ -5,4 +5,4 @@ unzip master.zip -d .
 cd Riot-Watcher-master
 python setup.py install
 cd ..
-# rm -r -f Riot-Watcher-master/
+rm -r -f Riot-Watcher-master/

--- a/server/gunicorn/mooncaker/external_tools/dataCrawler.py
+++ b/server/gunicorn/mooncaker/external_tools/dataCrawler.py
@@ -104,7 +104,7 @@ def clash_matches(lw, region, puuids, get_key):
         redo = True
         while redo:
             try:
-                match_list.append(lw.matchv5.matchlist_by_puuid(big_region, encr_puuid).get('matches')) #todo: filter by queue '700'
+                match_list.append(lw.matchv5.matchlist_by_puuid(big_region, encr_puuid))
                 redo = False
             except ApiError as err:
                 if err.response.status_code == 404:
@@ -207,9 +207,11 @@ def add_new_matches(lw, match_list, db_matches, region, get_key):
         redo = True
         while redo:
             try:
-                match = lw.match.by_id(region, g_id)
-                m2_frame = lw.match.timeline_by_match(region, g_id)['frames'][2]['participantFrames']
-                m_last_frame = lw.match.timeline_by_match(region, g_id)['frames'][-1]['participantFrames']
+                match = lw.matchv5.by_id(region, g_id)
+                if match['info']['queueId'] != 700: #get only clash queues: todo: improve code
+                    break
+                m2_frame = lw.matchv5.timeline_by_match(region, g_id)['frames'][2]['participantFrames']
+                m_last_frame = lw.matchv5.timeline_by_match(region, g_id)['frames'][-1]['participantFrames']
                 redo = False
                 m2_pos = {int(num): m2_frame[num]['position'] for num in m2_frame.keys()}
                 new_doc = {"_id": match["gameId"], "region": 'euw1', "duration": match["gameDuration"],

--- a/server/gunicorn/mooncaker/external_tools/dataCrawler.py
+++ b/server/gunicorn/mooncaker/external_tools/dataCrawler.py
@@ -4,6 +4,7 @@
 
 from riotwatcher import LolWatcher, ApiError
 from pymongo import MongoClient
+from functools import partial
 import argparse
 import re
 import time
@@ -12,9 +13,51 @@ import logging
 
 BIG_REGIONS = ['europe', 'americas', 'asia']
 REGIONS = ['euw1', 'eun1', 'kr', 'na1']
+#league api wants region=euw1,... while matchv5 wants region=europe,... (riot, hello?!)
 REGION2BIGREGION = {'euw1': 'europe', 'eun1': 'europe', 'kr': 'asia', 'na1': 'americas'}
 TIERS = ['DIAMOND', 'PLATINUM', 'GOLD', 'SILVER', 'BRONZE', 'IRON']
 DIVISIONS = ['I', 'II', 'III', 'IV']
+
+def set_new_key(watcher, new_key):
+    logging.debug("datacrawler: going to possibly hang while waiting new api key")
+    watcher._base_api._api_key = new_key() #todo: is this even the right way to set the new key?
+    logging.debug(f"datacrawler: received new api key ending with {watcher._base_api._api_key[-5:]}")
+
+def safe_api_call(command, wait_set_new_key, retry_count = 3):
+    """calls the given command and checks for the successful outcome
+    If the outcome is not successful, it intercepts the error and based on
+    that will either retry (up to 3 times) or return unsuccessful status
+
+    Args:
+        command (fun): a callable of the api to exec which was already given the arguments needed (use partial)
+        wait_set_new_key (fun): basically the defined set_new_key with the args already given
+        redo_count (int, optional): used internally to count how many times the call has been retried. Defaults to 3.
+
+    Returns:
+        [type]: [description]
+    """
+    result = None
+    call_is_successful = False
+    if retry_count > 0:
+        # redo call in case of errors up to x times
+        try:
+            result = command()
+            call_is_successful = True
+        except ApiError as err:
+            if err.response.status_code == 404:
+                logging.warning(f"datacrawler: Received a 404 status code with the following arguments")
+            elif err.response.status_code == 403:
+                logging.warning(f"datacrawler: Received a 403 status code, waiting new API")
+                wait_set_new_key() #todo: is it bad to hang inside except?
+            elif err.response.status_code == 429:
+                #todo: how many is too many ?
+                logging.warning("datacrawler: Received a 429 status code, too many same type requests, sleeping for 60s")
+                time.sleep(60)
+            else:
+                logging.warning(f"datacrawler: Received a {err.response.status_code} status code")
+        if not call_is_successful:
+            return safe_api_call(command, wait_set_new_key, retry_count - 1)
+    return call_is_successful, result
 
 def sum_name_id(lw, region, mode, tier, division, get_key):
     """
@@ -31,22 +74,12 @@ def sum_name_id(lw, region, mode, tier, division, get_key):
         Returns:
         List[List[String]]: list of players' summoner name and summonerId belonging to the given tier,division,region
     """
-    redo = True
-    players_list = []
-    while (redo):
-        try:
-            players_list = lw.league.entries(region, mode, tier, division)
-            redo = False
-        except ApiError as err:  # todo (medium): this error handling is repeated 3+ time can we make it modular?
-            if err.response.status_code == 403:
-                logging.warning(f"datacrawler: Received a 403 status code, waiting new API")
-                lw._base_api._api_key = get_key()
-            elif err.response.status_code == 429:
-                time.sleep(60)
-            else:
-                raise
-    return [summoner.get('summonerName') for summoner in players_list], [summoner.get('summonerId') for summoner in
-                                                                         players_list]
+    command2call = partial(lw.league.entries, region, mode, tier, division)
+    is_successful, players_list = safe_api_call(command2call, get_key)
+    if is_successful:
+        return [summoner.get('summonerName') for summoner in players_list], \
+               [summoner.get('summonerId') for summoner in players_list]
+    return None
 
 
 # gets account Ids of given summoners, returning None for accounts not found (che cazzo ne so anche se li ho appena fetchati dalla lega non li trova)
@@ -64,23 +97,13 @@ def acc_id_by_sum_name(lw, region, summoner_names, get_key):
         List[String]: list of accountIds associated to input summoner names, containing None if no accountId was found for the summoner name
     """
     ids = []
-    for name in summoner_names[:10]: #todo: what is this slicing for (?)
-        redo = True
-        while redo:
-            try:
-                ids.append(lw.summoner.by_name(region, name).get('puuid'))
-                redo = False
-            except ApiError as err:
-                if err.response.status_code == 404:
-                    ids.append(None)
-                    redo = False
-                elif err.response.status_code == 403:
-                    logging.warning(f"datacrawler: Received a 403 status code, waiting new API")
-                    lw._base_api._api_key = get_key()
-                elif err.response.status_code == 429:
-                    time.sleep(60)
-                else:
-                    raise
+    for name in summoner_names[:10]: #todo: what is this slicing for (?!)
+        command2call = partial(lw.summoner.by_name, region, name)
+        is_successful, user = safe_api_call(command2call, get_key)
+        if is_successful:
+            ids.append(user.get('puuid'))
+        # else:
+        #     ids.append(None) #todo: why is this ? - was present in previous version
     return ids
 
 
@@ -99,26 +122,14 @@ def clash_matches(lw, region, puuids, get_key):
         List[List[Dict]]: list containing a list of dictionaries with clash matches info for each accountId
     """
     match_list = []
-    big_region = REGION2BIGREGION[region]
+    big_region = REGION2BIGREGION[region] 
     for encr_puuid in puuids:
-        redo = True
-        while redo:
-            try:
-                match_list.append(lw.matchv5.matchlist_by_puuid(big_region, encr_puuid))
-                redo = False
-            except ApiError as err:
-                if err.response.status_code == 404:
-                    match_list.append(None)
-                    redo = False
-                elif err.response.status_code == 403:
-                    logging.warning(f"datacrawler: Received a 403 status code, waiting new API")
-                    lw._base_api._api_key = get_key()
-                elif err.response.status_code == 429:
-                    time.sleep(60)
-                else:
-                    raise
+        command2call = partial(lw.matchv5.matchlist_by_puuid, big_region, encr_puuid)
+        is_successful, matches = safe_api_call(command2call, get_key)
+        if is_successful:
+            match_list.append(matches)
     
-    match_list = list(filter(None, match_list))
+    match_list = list(filter(None, match_list)) #todo: might not be needed anymore
     return match_list
 
 
@@ -162,7 +173,7 @@ def cln_match(match_lists, db_matches):
     # game_ids = [match.get('gameId') for match in match_list]
     # game_ids = list(dict.fromkeys(game_ids))
     for g_id in match_lists:
-        if db_matches.count_documents({"_id": g_id}) > 0:
+        if db_matches.count_documents({"_id": g_id}) > 0: #TODO (high prio): g_id is now a string, is that a problem ?
             match_lists.remove(g_id)
     return match_lists
 
@@ -203,65 +214,59 @@ def add_new_matches(lw, match_list, db_matches, region, get_key):
         region(String): a server region
         get_key(Func): function that returns a new api key
     """
+    big_region = REGION2BIGREGION[region]
     for g_id in match_list:
-        redo = True
-        while redo:
-            try:
-                match = lw.matchv5.by_id(region, g_id)
-                if match['info']['queueId'] != 700: #get only clash queues: todo: improve code
-                    break
-                m2_frame = lw.matchv5.timeline_by_match(region, g_id)['frames'][2]['participantFrames']
-                m_last_frame = lw.matchv5.timeline_by_match(region, g_id)['frames'][-1]['participantFrames']
-                redo = False
-                m2_pos = {int(num): m2_frame[num]['position'] for num in m2_frame.keys()}
-                new_doc = {"_id": match["gameId"], "region": 'euw1', "duration": match["gameDuration"],
-                           "season": match["seasonId"],
-                           "patch": float(re.search('^\d+[.]\d+', match["gameVersion"]).group())}
-                teams = [team["teamId"] for team in match["teams"]]
-                new_doc["winner"] = teams[0] if match["teams"][0]["win"] == 'Win' else teams[1]
-                i = 0
-                bans = [[], []]
-                for team in match["teams"]:
-                    for ban in team["bans"]:
-                        bans[i].append(ban["championId"])
-                    i += 1
-                teams = ({"teamId": teams[0], "bans": bans[0]}, {"teamId": teams[1], "bans": bans[0]})
-                identities = {part["participantId"]: part["player"]["summonerId"] for part in
-                              match["participantIdentities"]}
-                bot = [[], []]
-                for player in match["participants"]:
-                    team = 0 if player["teamId"] == teams[0]["teamId"] else 1
-                    role = get_role(m2_pos[player["participantId"]], player)
-                    champion = player["championId"]
-                    sum_id = identities[player["participantId"]]
-                    if role != "BOT":
-                        teams[team][role] = {"summonerId": sum_id, "champion": champion}
-                    else:
-                        bot[team].append({"summonerId": sum_id, "champion": champion, "id": player["participantId"]})
-                if len(bot[0]) == 2 and len(bot[1]) == 2 and len(teams[0]) == 5 and len(teams[1]) == 5:
-                    for team in range(2):
-                        bot_roles = check_bot_roles(bot[team], m_last_frame)
-                        teams[team]["SUPPORT"] = bot_roles["SUPPORT"]
-                        teams[team]["ADC"] = bot_roles["ADC"]
-                    new_doc["team1"] = teams[0]
-                    new_doc["team2"] = teams[1]
-                    db_matches.insert_one(new_doc)
-            except ApiError as err:
-                if err.response.status_code == 404:
-                    logging.warning(f"datacrawler: Received a 404 status code when retrieving {g_id} game id")
-                    redo = False
-                elif err.response.status_code == 403:
-                    logging.warning(f"datacrawler: Received a 403 status code, waiting new API")
-                    lw._base_api._api_key = get_key()
-                elif err.response.status_code == 429:
-                    logging.warning(
-                        f"datacrawler: Received a 429 status code, too many same type requests, sleeping for 60s")
-                    time.sleep(60)
-                elif err.response.status_code == 504:  # todo decide if retry or skip, atm skip
-                    logging.warning(f"datacrawler: Received a 504 status code when retrieving {g_id} game id")
-                    redo = False
-                else:
-                    raise
+
+        #get match by id
+        command2call = partial(lw.matchv5.by_id, region, g_id)
+        is_successful, match = safe_api_call(command2call, get_key)
+        if not is_successful:
+            continue #unlucky
+
+        if match['info']['queueId'] != 700: #get only clash queues: todo: improve code
+            break
+
+        #get timeline to enstablish roles
+        command2call = partial(lw.matchv5.timeline_by_match, big_region, g_id)
+        is_successful, timeline = safe_api_call(command2call, get_key)
+        if not is_successful:
+            continue #unlucky part2
+
+        m2_frame = timeline['frames'][2]['participantFrames']
+        m_last_frame = timeline['frames'][-1]['participantFrames']
+        m2_pos = {int(num): m2_frame[num]['position'] for num in m2_frame.keys()}
+        new_doc = {"_id": match["gameId"], "region": region, "duration": match["gameDuration"],
+                    "season": match["seasonId"],
+                    "patch": float(re.search('^\d+[.]\d+', match["gameVersion"]).group())}
+        teams = [team["teamId"] for team in match["teams"]]
+        new_doc["winner"] = teams[0] if match["teams"][0]["win"] == 'Win' else teams[1]
+        i = 0
+        bans = [[], []]
+        for team in match["teams"]:
+            for ban in team["bans"]:
+                bans[i].append(ban["championId"])
+            i += 1
+        teams = ({"teamId": teams[0], "bans": bans[0]}, {"teamId": teams[1], "bans": bans[0]})
+        identities = {part["participantId"]: part["player"]["summonerId"] for part in
+                        match["participantIdentities"]}
+        bot = [[], []]
+        for player in match["participants"]:
+            team = 0 if player["teamId"] == teams[0]["teamId"] else 1
+            role = get_role(m2_pos[player["participantId"]], player)
+            champion = player["championId"]
+            sum_id = identities[player["participantId"]]
+            if role != "BOT":
+                teams[team][role] = {"summonerId": sum_id, "champion": champion}
+            else:
+                bot[team].append({"summonerId": sum_id, "champion": champion, "id": player["participantId"]})
+        if len(bot[0]) == 2 and len(bot[1]) == 2 and len(teams[0]) == 5 and len(teams[1]) == 5:
+            for team in range(2):
+                bot_roles = check_bot_roles(bot[team], m_last_frame)
+                teams[team]["SUPPORT"] = bot_roles["SUPPORT"]
+                teams[team]["ADC"] = bot_roles["ADC"]
+            new_doc["team1"] = teams[0]
+            new_doc["team2"] = teams[1]
+            db_matches.insert_one(new_doc)
 
 
 def get_uncrawled(db):
@@ -283,16 +288,18 @@ def start_crawling(API_KEY, get_key, db_url = "mongodb://datacaker:27017"):
     to_crawl = get_uncrawled(db)
     db_rediti= db.get_collection("ReDiTi")
     lol_watcher = LolWatcher(API_KEY)
+    key_set = partial(set_new_key, lol_watcher)
     for elem in to_crawl:
         region = elem['region']
         tier = elem['tier']
         division = elem['division']
         logging.info(f"datacrawler: Crawling {region}, {tier}, {division}")
-        accounts = account_info(lol_watcher, region, 'RANKED_SOLO_5x5', tier, division, get_key) #todo: not hardcode mode
-        match_lists = clash_matches(lol_watcher, region, [account.get('puuid') for account in accounts],
-                                    get_key)
+        accounts = account_info(lol_watcher, region, 'RANKED_SOLO_5x5', tier, division, key_set) #todo: not hardcode mode
+        match_lists = clash_matches(lol_watcher, region,
+                                    [account.get('puuid') for account in accounts],
+                                    key_set)
         match_list = cln_match(match_lists, db_matches)
-        add_new_matches(lol_watcher, match_list, db_matches, region, get_key)
+        add_new_matches(lol_watcher, match_list, db_matches, region, key_set)
         db_rediti.update_one({'_id': elem['_id']}, {'$set': {'crawled': True}})
 
 def main():
@@ -301,9 +308,17 @@ def main():
     parser.add_argument('--API-file', help='the filename with the riot API key')
     parser.add_argument('--API', help='the riot API key')
     parser.add_argument('--db-url', help='the url of the mongo db, default is localhost')
-    parser.add_argument('--no-db', help= 'if given true it will only test the connection to riot API', action='store_true')
+    parser.add_argument('--test-api', help='if given it will only test the connection to riot API without the database',
+                        action='store_true')
+    parser.add_argument('--test-db', help= 'if given it will only test the database without accessing the api',
+    action='store_true')
     args = vars(parser.parse_args())
 
+    if args['test_db'] == True:
+        #todo: test the database
+        return 
+    
+    # Check avilability of API key
     if args['API'] is None and args['API_file'] is None:
         print("You must either provide the API through the command line or through a file")
         parser.print_help()
@@ -320,13 +335,9 @@ def main():
         except FileNotFoundError:
             print("Couldn't find the specified file with the RIOT API key, please check again")
             return
-
-    db_url = "mongodb://localhost:27017" if args['db_url'] is None else args['db_url']
-
-    if args['no_db'] != True:
-        start_crawling(RIOT_API_KEY, input, db_url)
-    else:
-        #begin test without db
+    
+    if args['test_api'] == True:
+        # test only api connection without db    
         import random
         region = random.choice(REGIONS)
         tier = random.choice(TIERS)
@@ -343,12 +354,17 @@ def main():
         match_list = [match for matches in match_lists for match in matches]
         for g_id in match_list[:20]:
             print("Getting match by id", flush=True)
-            match = watcher.match.by_id(region, g_id)
+            watcher.matchv5.by_id(region, g_id)
             print("Got match by id", flush=True)
-            m2_frame = watcher.match.timeline_by_match(region, g_id)['frames'][2]['participantFrames']
-            m_last_frame = watcher.match.timeline_by_match(region, g_id)['frames'][-1]['participantFrames']
+            watcher.matchv5.timeline_by_match(region, g_id)['frames'][2]['participantFrames']
+            watcher.matchv5.timeline_by_match(region, g_id)['frames'][-1]['participantFrames']
             print("Successfully crawled one match", flush=True)
         print("Successfully crawled 20 matches", flush=True)
+        return
 
+    db_url = "mongodb://localhost:27017" if args['db_url'] is None else args['db_url']
+
+    start_crawling(RIOT_API_KEY, input, db_url)
+    
 if __name__ == "__main__":
     main()

--- a/server/gunicorn/mooncaker/external_tools/dataCrawler.py
+++ b/server/gunicorn/mooncaker/external_tools/dataCrawler.py
@@ -158,13 +158,13 @@ def cln_match(match_lists, db_matches):
         Returns:
         List[Dict]: list of clash games ids
     """
-    match_list = [match for matches in match_lists for match in matches]
-    game_ids = [match.get('gameId') for match in match_list]
-    game_ids = list(dict.fromkeys(game_ids))
-    for g_id in game_ids:
+    # match_list = [match for matches in match_lists for match in matches]
+    # game_ids = [match.get('gameId') for match in match_list]
+    # game_ids = list(dict.fromkeys(game_ids))
+    for g_id in match_lists:
         if db_matches.count_documents({"_id": g_id}) > 0:
-            game_ids.remove(g_id)
-    return game_ids
+            match_lists.remove(g_id)
+    return match_lists
 
 
 def check_jungler(player):
@@ -341,9 +341,7 @@ def main():
         match_lists = clash_matches(watcher, region, [account.get('puuid') for account in accounts], input)
         print("Match list retrieved", flush=True) 
         match_list = [match for matches in match_lists for match in matches]
-        game_ids = [match.get('gameId') for match in match_list]
-        game_ids = list(dict.fromkeys(game_ids))
-        for g_id in game_ids[:20]:
+        for g_id in match_list[:20]:
             print("Getting match by id", flush=True)
             match = watcher.match.by_id(region, g_id)
             print("Got match by id", flush=True)

--- a/server/gunicorn/requirements.txt
+++ b/server/gunicorn/requirements.txt
@@ -7,6 +7,5 @@ flask_restful==0.3.9
 flask_wtf==0.15.1
 pymongo==3.11.4
 python-dotenv==0.17.1
-riotwatcher==3.1.1
 WTForms==2.3.3
 flask_talisman==0.8.0


### PR DESCRIPTION
Changes to the data crawler:

Match v5 Support:

- Changed database fields accordingly
- Changed account info retrieval to use puuid instead of account id (as Riot is moving toward this)
![image](https://user-images.githubusercontent.com/10598113/123247577-54ca2580-d4e7-11eb-9ad2-7d3c2952fe19.png)
- Added support for new big region semantics: were previously euw1, eune1, ... they are now grouped into americas, europe, ...
- Match retrieval by queue is not available anymore, now it retrieves all matches and filters them later on.
(Match V5 support for queue filtering may be implemented later on)
![image](https://user-images.githubusercontent.com/10598113/123247389-25b3b400-d4e7-11eb-854a-154a8a44a862.png)


Changed retrieval order: now going in batches of users.
Wrapped each Riot Watcher API call into a function that handles bad status codes.
Added more arguments for the database URL, and testing of API and DB separately (DB is still WIP)
